### PR TITLE
Fixed various typos

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
 
 	<p>The Array is Javascript's only collection type. Arrays are everywhere. We're going to add the five functions to
 		the Array type, and in the process make it much more powerful and useful. As a matter of fact, Array already has
-		the map, filter, and reduce functions! However we're going to to reimplement these functions as a learning
+		the map, filter, and reduce functions! However we're going to reimplement these functions as a learning
 		exercise.</p>
 
 	<p>This section will follow a pattern. First we'll solve problems the way you probably learned in school, or on your
@@ -4618,7 +4618,7 @@
 			not getting out of order requests coming back? For example if I type "react" then type "reactive" I want
 			"reactive" to be my result, regardless of which actually returned first from the service.</p>
 
-		<p>In the example below, you will be receiving a sequence of key presses, a textbox, and a function when called
+		<p>In the example below, you will be receiving a sequence of key presses, a text box, and a function when called
 			returns an array of search results.</p>
 		<pre>
 			getSearchResultSet('react') === seq[,,,["reactive", "reaction","reactor"]]
@@ -4716,7 +4716,7 @@
 	<div class="lesson">
 		<h4>Exercise 40: Distinct Until Changed Input</h4>
 
-		<p>You'll notice in the previous exercise that if you pressed your arrow keys while inside the textbox, the query
+		<p>You'll notice in the previous exercise that if you pressed your arrow keys while inside the text box, the query
 			will still fire, regardless of whether the text actually changed or not. How do we prevent that? The
 			distinctUntilChanged filters out successive repetitive values.</p>
 		<pre>
@@ -4901,7 +4901,7 @@
 	<div class="lesson">
 		<h4>Exercise 42: Retrying after errors</h4>
 
-		<p>You'll notice in the previous exercise that if you pressed your arrow keys while inside the textbox, the query
+		<p>You'll notice in the previous exercise that if you pressed your arrow keys while inside the text  box, the query
 			will still fire, regardless of whether the text actually changed or not. How do we prevent that? The
 			distinctUntilChanged filters out successive repetitive values.</p>
 		<pre>


### PR DESCRIPTION
Corrected an instance of dittography ("to to" written for "to"), and changed "textbox" to "text box" in descriptive passages (but not `textBox`).
